### PR TITLE
Framework

### DIFF
--- a/amorphie.consent.core/DTO/HhsConsentDto.cs
+++ b/amorphie.consent.core/DTO/HhsConsentDto.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using amorphie.core.Base;
+
+namespace amorphie.consent.core.Model;
+
+public class HhsConsentDto : DtoBase
+{   
+    public string AdditionalData { get; set; }
+    public List<TokenModel> Token { get; set; }
+}

--- a/amorphie.consent.core/Model/Consent.cs
+++ b/amorphie.consent.core/Model/Consent.cs
@@ -15,4 +15,6 @@ public class Consent : EntityBase
     public ConsentPermission ConsentPermission { get; set; }
     [NotMapped]
     public virtual NpgsqlTsVector SearchVector { get; set; }
+
+    
 }

--- a/amorphie.consent.core/Model/HHSModels.cs
+++ b/amorphie.consent.core/Model/HHSModels.cs
@@ -1,14 +1,14 @@
 public class HesapHizmetiSağlayici
 {
-    public string HhsKod { get; set; }
-    public string YosKod { get; set; }
+    public IzinBilgisi iznBlg { get; set; }
+
 }
 
 public class GucLuKimlikDogrulama
 {
     public string YetYntm { get; set; }
     public string YonAdr { get; set; }
-    public string BldAdr { get; set; }
+    // public string BldAdr { get; set; }
     public string HhsYonAdr { get; set; }
     public DateTime YetTmmZmn { get; set; }
 }
@@ -27,14 +27,14 @@ public class HesapBilgisiRizaBilgisi
     public DateTime OlusZmn { get; set; }
     public DateTime GnclZmn { get; set; }
     public string RizaDrm { get; set; }
-    public string RizaIptDtyKod { get; set; }
+    // public string RizaIptDtyKod { get; set; }
 }
 
 public class Kimlik
 {
-    public string OhkTur { get; set; }
     public string KimlikTur { get; set; }
     public string KimlikVrs { get; set; }
+    public string ohkTur { get; set; }
 }
 
 public class KatilimciBilgisi
@@ -64,7 +64,6 @@ public class HesapBilgisiRizaIstegiResponse
     public KatilimciBilgisi KatilimciBlg { get; set; }
     public GucLuKimlikDogrulama Gkd { get; set; }
     public HesapHizmetiSağlayici HspBlg { get; set; }
-    public IzinBilgisi IznBlg { get; set; }
     public AyrintiBilgi AyrintiBlg { get; set; }
 }
 

--- a/amorphie.consent.core/Model/HHSModels.cs
+++ b/amorphie.consent.core/Model/HHSModels.cs
@@ -1,0 +1,110 @@
+public class HesapHizmetiSağlayıcı
+{
+    public string HhsKod { get; set; }
+    public string YosKod { get; set; }
+}
+
+public class GucLuKimlikDogrulama
+{
+    public string YetYntm { get; set; }
+    public string YonAdr { get; set; }
+    public string BldAdr { get; set; }
+    public string HhsYonAdr { get; set; }
+    public DateTime YetTmmZmn { get; set; }
+}
+
+public class IzinBilgisi
+{
+    public string[] IzinTur { get; set; }
+    public DateTime ErisimIzniSonTrh { get; set; }
+    public DateTime? HesapIslemBslZmn { get; set; }
+    public DateTime? HesapIslemBtsZmn { get; set; }
+}
+
+public class HesapBilgisiRizaBilgisi
+{
+    public string RizaNo { get; set; }
+    public DateTime OlusZmn { get; set; }
+    public DateTime GnclZmn { get; set; }
+    public string RizaDrm { get; set; }
+    public string RizaIptDtyKod { get; set; }
+}
+
+public class Kimlik
+{
+    public string OhkTur { get; set; }
+    public string KimlikTur { get; set; }
+    public string KimlikVrs { get; set; }
+}
+
+public class KatilimciBilgisi
+{
+    public string HhsKod { get; set; }
+    public string YosKod { get; set; }
+}
+public class AyrintiBilgi
+{
+    public string OhkMsj { get; set; }
+}
+
+public class HesapBilgisiRizaIstegi
+{
+    public HesapBilgisiRizaBilgisi RzBlg { get; set; }
+    public Kimlik Kmlk { get; set; }
+    public KatilimciBilgisi KatilimciBlg { get; set; }
+    public GucLuKimlikDogrulama Gkd { get; set; }
+    public HesapHizmetiSağlayıcı HspBlg { get; set; }
+    public IzinBilgisi IznBlg { get; set; }
+}
+
+public class HesapBilgisiRizaIstegiResponse
+{
+    public HesapBilgisiRizaBilgisi RzBlg { get; set; }
+    public Kimlik Kmlk { get; set; }
+    public KatilimciBilgisi KatilimciBlg { get; set; }
+    public GucLuKimlikDogrulama Gkd { get; set; }
+    public HesapHizmetiSağlayıcı HspBlg { get; set; }
+    public IzinBilgisi IznBlg { get; set; }
+    public AyrintiBilgi AyrintiBlg { get; set; }
+}
+
+// public class HesapBilgisiRizaBilgisiDto
+// {
+//     public string RizaNo { get; set; }
+//     public DateTime OlusZmn { get; set; }
+//     public DateTime GnclZmn { get; set; }
+//     public string RizaDrm { get; set; }
+//     public string RizaIptDtyKod { get; set; }
+// }
+
+// public class KimlikDto
+// {
+//     public string KimlikTur { get; set; }
+//     public string KimlikVrs { get; set; }
+//     public string KrmKmlkTur { get; set; }
+//     public string KrmKmlkVrs { get; set; }
+//     public string OhkTur { get; set; }
+// }
+
+// public class KatilimciBilgisiDto
+// {
+//     public string HhsKod { get; set; }
+//     public string YosKod { get; set; }
+// }
+
+// public class GucLuKimlikDogrulamaDto
+// {
+//     public string YetYntm { get; set; }
+//     public string YonAdr { get; set; }
+//     public string BldAdr { get; set; }
+//     public string HhsYonAdr { get; set; }
+//     public DateTime YetTmmZmn { get; set; }
+// }
+
+// public class IzinBilgisiDto
+// {
+//     public string[] IzinTur { get; set; }
+//     public DateTime ErisimIzniSonTrh { get; set; }
+//     public DateTime? HesapIslemBslZmn { get; set; }
+//     public DateTime? HesapIslemBtsZmn { get; set; }
+// }

--- a/amorphie.consent.core/Model/HHSModels.cs
+++ b/amorphie.consent.core/Model/HHSModels.cs
@@ -1,3 +1,5 @@
+using amorphie.core.Base;
+
 public class HesapHizmetiSağlayici
 {
     public IzinBilgisi iznBlg { get; set; }
@@ -65,6 +67,15 @@ public class HesapBilgisiRizaIstegiResponse
     public GucLuKimlikDogrulama Gkd { get; set; }
     public HesapHizmetiSağlayici HspBlg { get; set; }
     public AyrintiBilgi AyrintiBlg { get; set; }
+}
+
+public class TokenModel
+{
+    public Guid Id { get; set; }
+    public string erisimBelirteci { get; set; }
+    public int gecerlilikSuresi { get; set; }
+    public string yenilemeBelirteci { get; set; }
+    public int yenilemeBelirteciGecerlilikSuresi { get; set; }
 }
 
 // public class HesapBilgisiRizaBilgisiDto

--- a/amorphie.consent.core/Model/HHSModels.cs
+++ b/amorphie.consent.core/Model/HHSModels.cs
@@ -1,4 +1,4 @@
-public class HesapHizmetiSağlayıcı
+public class HesapHizmetiSağlayici
 {
     public string HhsKod { get; set; }
     public string YosKod { get; set; }
@@ -53,7 +53,7 @@ public class HesapBilgisiRizaIstegi
     public Kimlik Kmlk { get; set; }
     public KatilimciBilgisi KatilimciBlg { get; set; }
     public GucLuKimlikDogrulama Gkd { get; set; }
-    public HesapHizmetiSağlayıcı HspBlg { get; set; }
+    public HesapHizmetiSağlayici HspBlg { get; set; }
     public IzinBilgisi IznBlg { get; set; }
 }
 
@@ -63,7 +63,7 @@ public class HesapBilgisiRizaIstegiResponse
     public Kimlik Kmlk { get; set; }
     public KatilimciBilgisi KatilimciBlg { get; set; }
     public GucLuKimlikDogrulama Gkd { get; set; }
-    public HesapHizmetiSağlayıcı HspBlg { get; set; }
+    public HesapHizmetiSağlayici HspBlg { get; set; }
     public IzinBilgisi IznBlg { get; set; }
     public AyrintiBilgi AyrintiBlg { get; set; }
 }

--- a/amorphie.consent/Mapper/ResourceMapper.cs
+++ b/amorphie.consent/Mapper/ResourceMapper.cs
@@ -12,6 +12,7 @@ namespace amorphie.consent.Mapper
         public ResourceMapper()
         {
             CreateMap<Consent, ConsentDTO>().ReverseMap();
+            CreateMap<Consent,HesapBilgisiRizaIstegiResponse>().ReverseMap();
             CreateMap<Consent, OpenBankingConsentDTO>()
                 .ForMember(dest => dest.ConsentPermission, opt => opt.MapFrom(src => src.ConsentPermission)) // Handle ConsentPermission mapping
                 .ReverseMap();

--- a/amorphie.consent/Mapper/ResourceMapper.cs
+++ b/amorphie.consent/Mapper/ResourceMapper.cs
@@ -20,6 +20,67 @@ namespace amorphie.consent.Mapper
             CreateMap<ConsentDefinition, ConsentDefinitionDTO>().ReverseMap();
             CreateMap<Token, TokenDto>().ReverseMap();
             CreateMap<ConsentDataDto, Consent>().ReverseMap();
+            CreateMap<Consent,HhsConsentDto>().ReverseMap();
+            // CreateMap<Token, TokenModel>().ReverseMap();
+            CreateMap<Consent, HhsConsentDto>().ForMember(dest => dest.Token, opt => opt.MapFrom(src => src.Token)).ReverseMap();
+              CreateMap<TokenModel, (Token erisimToken, Token yenilemeToken)>()
+            .ConstructUsing((src, ctx) =>
+            {
+                var erisimToken = new Token
+                {
+                    TokenValue = src.erisimBelirteci,
+                    TokenType = "Access Token",
+                    ExpireTime = src.gecerlilikSuresi,
+                    ConsentId = src.Id
+                };
+
+                var yenilemeToken = new Token
+                {
+                    TokenValue = src.yenilemeBelirteci,
+                    TokenType = "Refresh Token",
+                    ExpireTime = src.yenilemeBelirteciGecerlilikSuresi,
+                    ConsentId = src.Id
+                };
+
+                return (erisimToken, yenilemeToken);
+            }).ReverseMap();
+
+            CreateMap<TokenModel, (Token erisimToken, Token yenilemeToken)>()
+    .ConstructUsing((src, ctx) =>
+    {
+        Token? erisimToken = null;
+        Token? yenilemeToken = null;
+
+        if (src.erisimBelirteci != null)
+        {
+            erisimToken = new Token
+            {
+                TokenValue = src.erisimBelirteci,
+                TokenType = "Access Token",
+                ExpireTime = src.gecerlilikSuresi,
+                ConsentId = src.Id
+            };
+        }
+
+        if (src.yenilemeBelirteci != null)
+        {
+            yenilemeToken = new Token
+            {
+                TokenValue = src.yenilemeBelirteci,
+                TokenType = "Refresh Token",
+                ExpireTime = src.yenilemeBelirteciGecerlilikSuresi,
+                ConsentId = src.Id
+            };
+        }
+
+        return (erisimToken, yenilemeToken);
+    }).ReverseMap();
+       CreateMap<Token, TokenModel>()
+        .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))
+        .ForMember(dest => dest.erisimBelirteci, opt => opt.MapFrom(src => src.TokenValue))
+        .ForMember(dest => dest.gecerlilikSuresi, opt => opt.MapFrom(src => src.ExpireTime))
+        .ForMember(dest => dest.yenilemeBelirteci, opt => opt.MapFrom(src => src.TokenValue))
+        .ForMember(dest => dest.yenilemeBelirteciGecerlilikSuresi, opt => opt.MapFrom(src => src.ExpireTime));
         }
     }
 }

--- a/amorphie.consent/Module/ConsentModule.cs
+++ b/amorphie.consent/Module/ConsentModule.cs
@@ -198,4 +198,6 @@ public class ConsentModule : BaseBBTRoute<ConsentDTO, Consent, ConsentDbContext>
             : Results.NoContent();
     }
     #endregion
+
+    
 }

--- a/amorphie.consent/Module/OpenBankingConsentModule.cs
+++ b/amorphie.consent/Module/OpenBankingConsentModule.cs
@@ -29,6 +29,9 @@ public class OpenBankingConsentModule : BaseBBTRoute<OpenBankingConsentDTO, Cons
         routeGroupBuilder.MapGet("/search", SearchMethod);
         routeGroupBuilder.MapGet("/getByUserId/{userId}", GetConsentWithPermissionsAndTokenByUserId);
         routeGroupBuilder.MapPost("/hhs", HhsPost);
+        routeGroupBuilder.MapPost("/hhs/token", HhsToken);
+        routeGroupBuilder.MapGet("/hhs/{consentId}", GetHhsConsentWithTokensById);
+        routeGroupBuilder.MapGet("/hhs/consentType/{consentType}", GetHhsConsentWithTokensByType);
     }
 
 
@@ -76,6 +79,106 @@ public class OpenBankingConsentModule : BaseBBTRoute<OpenBankingConsentDTO, Cons
         }
     }
 
+ public async Task<IResult> GetHhsConsentWithTokensById(
+    Guid consentId,
+    [FromServices] ConsentDbContext context,
+    [FromServices] IMapper mapper)
+{
+    try
+    {
+        var consentWithTokens = await context.Consents
+            .Include(c => c.Token)
+            .FirstOrDefaultAsync(c => c.Id == consentId);
+
+        if (consentWithTokens == null)
+        {
+            return Results.NotFound("Consent not found.");
+        }
+
+        var accessTokens = consentWithTokens.Token
+            .Where(token => token.TokenType == "Access Token" && !string.IsNullOrEmpty(token.TokenValue))
+            .ToList();
+
+        var refreshTokens = consentWithTokens.Token
+            .Where(token => token.TokenType == "Refresh Token" && !string.IsNullOrEmpty(token.TokenValue))
+            .ToList();
+
+        if (accessTokens.Count == 0 || refreshTokens.Count == 0)
+        {
+            return Results.Problem("Both access and refresh tokens are required.");
+        }
+
+        var hhsConsentDTO = new HhsConsentDto
+        {
+            Id = consentWithTokens.Id,
+            AdditionalData = consentWithTokens.AdditionalData,
+            Token = accessTokens.Zip(refreshTokens, (access, refresh) => new TokenModel
+            {
+                Id = access.ConsentId,
+                erisimBelirteci = access.TokenValue,
+                gecerlilikSuresi = access.ExpireTime,
+                yenilemeBelirteci = refresh.TokenValue,
+                yenilemeBelirteciGecerlilikSuresi = refresh.ExpireTime
+            }).ToList()
+        };
+
+        return Results.Ok(hhsConsentDTO);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"An error occurred: {ex.Message}");
+    }
+}
+public async Task<IResult> GetHhsConsentWithTokensByType(
+    string consentType,
+    [FromServices] ConsentDbContext context,
+    [FromServices] IMapper mapper)
+{
+    try
+    {
+        var consentWithTokens = await context.Consents
+            .Include(c => c.Token)
+            .FirstOrDefaultAsync(c => c.ConsentType == consentType);
+
+        if (consentWithTokens == null)
+        {
+            return Results.NotFound("Consent not found.");
+        }
+
+        var accessTokens = consentWithTokens.Token
+            .Where(token => token.TokenType == "Access Token" && !string.IsNullOrEmpty(token.TokenValue))
+            .ToList();
+
+        var refreshTokens = consentWithTokens.Token
+            .Where(token => token.TokenType == "Refresh Token" && !string.IsNullOrEmpty(token.TokenValue))
+            .ToList();
+
+        if (accessTokens.Count == 0 || refreshTokens.Count == 0)
+        {
+            return Results.Problem("Both access and refresh tokens are required.");
+        }
+
+        var hhsConsentDTO = new HhsConsentDto
+        {
+            Id = consentWithTokens.Id,
+            AdditionalData = consentWithTokens.AdditionalData,
+            Token = accessTokens.Zip(refreshTokens, (access, refresh) => new TokenModel
+            {
+                Id = access.ConsentId,
+                erisimBelirteci = access.TokenValue,
+                gecerlilikSuresi = access.ExpireTime,
+                yenilemeBelirteci = refresh.TokenValue,
+                yenilemeBelirteciGecerlilikSuresi = refresh.ExpireTime
+            }).ToList()
+        };
+
+        return Results.Ok(hhsConsentDTO);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"An error occurred: {ex.Message}");
+    }
+}
     protected async Task<IResult> GetConsentWithPermissionsAndTokenByUserId(Guid userId,
     [FromServices] ConsentDbContext context,
     [FromServices] IMapper mapper)
@@ -92,7 +195,7 @@ public class OpenBankingConsentModule : BaseBBTRoute<OpenBankingConsentDTO, Cons
             {
                 return Results.NotFound("Consents not found for the specified user.");
             }
-            
+
             //Can there be more than one consent for a userId? Therefore, would it be more sensible to return the data in a list format?
             var consentDTOs = mapper.Map<IList<OpenBankingConsentDTO>>(consents);
             return Results.Ok(consentDTOs);
@@ -103,41 +206,65 @@ public class OpenBankingConsentModule : BaseBBTRoute<OpenBankingConsentDTO, Cons
         }
     }
 
-  protected async Task<IResult> HhsPost([FromBody] HesapBilgisiRizaIstegiResponse dto,
+
+
+    protected async Task<IResult> HhsPost([FromBody] HesapBilgisiRizaIstegiResponse dto,
+      [FromServices] ConsentDbContext context,
+      [FromServices] IMapper mapper)
+    {
+        try
+        {
+            var consent = mapper.Map<Consent>(dto);
+
+            var additionalData = new
+            {
+                dto.RzBlg,
+                dto.Kmlk,
+                dto.KatilimciBlg,
+                dto.Gkd,
+                dto.HspBlg,
+                dto.AyrintiBlg
+            };
+
+            consent.AdditionalData = JsonSerializer.Serialize(additionalData);
+
+            if (dto.RzBlg?.RizaDrm != null)
+            {
+                consent.State = dto.RzBlg?.RizaDrm!;
+                consent.ConsentType = "AccountInfoConsent";
+            }
+
+            context.Consents.Add(consent);
+            await context.SaveChangesAsync();
+            return Results.Ok(consent);
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem($"An error occurred: {ex.Message}");
+        }
+    }
+    protected async Task<IResult> HhsToken([FromBody] TokenModel tokenModel,
     [FromServices] ConsentDbContext context,
     [FromServices] IMapper mapper)
-{
-    try
     {
-        var consent = mapper.Map<Consent>(dto);
-
-        var additionalData = new
+        try
         {
-            dto.RzBlg,
-            dto.Kmlk,
-            dto.KatilimciBlg,
-            dto.Gkd,
-            dto.HspBlg,
-            dto.AyrintiBlg
-        };
+            var (erisimToken, yenilemeToken) = mapper.Map<(Token, Token)>(tokenModel);
 
-        consent.AdditionalData = JsonSerializer.Serialize(additionalData);
+            context.Tokens.Add(erisimToken);
+            context.Tokens.Add(yenilemeToken);
+            await context.SaveChangesAsync();
+            var tokenList = new[] { erisimToken, yenilemeToken }
+                .Select(mapper.Map<Token>)
+                .ToList();
 
-        if (dto.RzBlg?.RizaDrm != null)
-        {
-            consent.State = dto.RzBlg?.RizaDrm!;
-            consent.ConsentType = "AccountInfoConsent";
+            return Results.Ok(tokenList);
         }
-
-        context.Consents.Add(consent);
-        await context.SaveChangesAsync();
-        return Results.Ok(consent);
+        catch (Exception ex)
+        {
+            return Results.Problem($"An error occurred: {ex.Message}");
+        }
     }
-    catch (Exception ex)
-    {
-        return Results.Problem($"An error occurred: {ex.Message}");
-    }
-}
     protected async ValueTask<IResult> SearchMethod(
       [FromServices] ConsentDbContext context,
       [FromServices] IMapper mapper,
@@ -168,4 +295,12 @@ public class OpenBankingConsentModule : BaseBBTRoute<OpenBankingConsentDTO, Cons
             ? Results.Ok(mapper.Map<IList<OpenBankingConsentDTO>>(resultList))
             : Results.NoContent();
     }
+    private (TokenModel erisimToken, TokenModel yenilemeToken) MapTokens(List<Token> tokens, IMapper mapper)
+{
+    var erisimToken = mapper.Map<TokenModel>(tokens.FirstOrDefault(t => t.TokenType == "Access Token"));
+    var yenilemeToken = mapper.Map<TokenModel>(tokens.FirstOrDefault(t => t.TokenType == "Refresh Token"));
+
+    return (erisimToken, yenilemeToken);
+}
+
 }

--- a/docs/hhs.puml
+++ b/docs/hhs.puml
@@ -1,0 +1,70 @@
+@startuml
+!define primary_key(x) <b><color:#b8861b><&key></color> x</b>
+!define foreign_key(x) <color:#aaaaaa><&key></color> x
+!define column(x) <color:#efefef><&media-record></color> x
+!define table(x) entity x << (T, white) >>
+
+table(HesapHizmetiSağlayıcı) {
+    column(HhsKod): CHARACTER VARYING
+    column(YosKod): CHARACTER VARYING
+}
+
+table(GucLuKimlikDogrulama) {
+    column(YetYntm): CHARACTER VARYING
+    column(YonAdr): CHARACTER VARYING
+    column(BldAdr): CHARACTER VARYING
+    column(HhsYonAdr): CHARACTER VARYING
+    column(YetTmmZmn): DateTime
+}
+
+table(IzinBilgisi) {
+    column(IzinTur): CHARACTER VARYING []
+    column(ErisimIzniSonTrh): DateTime
+    column(HesapIslemBslZmn): DateTime
+    column(HesapIslemBtsZmn): DateTime
+}
+
+table(HesapBilgisiRizaBilgisi) {
+    column(RizaNo): CHARACTER VARYING
+    column(OlusZmn): DateTime
+    column(GnclZmn): DateTime
+    column(RizaDrm): CHARACTER VARYING
+    column(RizaIptDtyKod): CHARACTER VARYING
+}
+
+table(Kimlik) {
+    column(OhkTur): CHARACTER VARYING
+    column(KimlikTur): CHARACTER VARYING
+    column(KimlikVrs): CHARACTER VARYING
+}
+
+table(KatilimciBilgisi) {
+    column(HhsKod): CHARACTER VARYING
+    column(YosKod): CHARACTER VARYING
+}
+
+table(AyrintiBilgi) {
+    column(OhkMsj): CHARACTER VARYING
+}
+
+table(HesapBilgisiRizaIstegi) {
+    column(RzBlg): HesapBilgisiRizaBilgisi
+    column(Kmlk): Kimlik
+    column(KatilimciBlg): KatilimciBilgisi
+    column(Gkd): GucLuKimlikDogrulama
+    column(HspBlg): HesapHizmetiSağlayıcı
+    column(IznBlg): IzinBilgisi
+    column(AyrBlg)?: AyrintiBilgi
+}
+
+table(HesapBilgisiRizaIstegiResponse) {
+    column(RzBlg): HesapBilgisiRizaBilgisi
+    column(Kmlk): Kimlik
+    column(KatilimciBlg): KatilimciBilgisi
+    column(Gkd): GucLuKimlikDogrulama
+    column(HspBlg): HesapHizmetiSağlayıcı
+    column(IznBlg): IzinBilgisi
+    column(AyrBlg): AyrintiBilgi
+}
+
+@enduml


### PR DESCRIPTION
#### Description

"Get methods based on ConsentId and ConsentType were added. Token mapping process and HHS consent post method were also implemented."

Fixes # (issue)

#### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

#### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

**New Feature:**
- Introduced new classes and properties in `amorphie.consent.core.Model` for enhanced data handling.
- Added new routes and methods in `OpenBankingConsentModule` to support additional functionalities.
- Enhanced `ResourceMapper` with new mappings between different types for improved data transformation.

**Refactor:**
- Removed commented-out classes in `HHSModels.cs` for cleaner codebase.

**Documentation:**
- Added a UML diagram in `hhs.puml` to provide a visual representation of the data model.

> 🎉 Here's to the code that grows,  
> With every pull request, it shows.  
> New features bright as morning sun,  
> Refactoring done, documentation spun.  
> In the world of tech, we sow the seeds,  
> Celebrating each PR, like a good deed! 🥳

<!-- end of auto-generated comment: release notes by coderabbit.ai -->