### PR TITLE
Sprint10 Consent LastValidAccess Date Changes, Cancel Methods

### DIFF
--- a/amorphie.consent.core/DTO/Authorization/SaveConsentForLoginDto.cs
+++ b/amorphie.consent.core/DTO/Authorization/SaveConsentForLoginDto.cs
@@ -6,4 +6,6 @@ public class SaveConsentForLoginDto
     public string ClientCode { get; set; }
     public long UserTCKN { get; set; }
     public long ScopeTCKN { get; set; }
+    
+    public DateTime? LastValidAccessDate { get; set; }
 }

--- a/amorphie.consent.core/DTO/Consent/CancelLoginConsentDto.cs
+++ b/amorphie.consent.core/DTO/Consent/CancelLoginConsentDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace amorphie.consent.core.DTO.Consent;
+
+public class CancelLoginConsentDto
+{
+    [Required]
+    public string ClientCode { get; set; }
+    [Required]
+    public long UserTCKN { get; set; }
+    [Required]
+    public long ScopeTCKN { get; set; }
+}

--- a/amorphie.consent.core/DTO/ConsentDto.cs
+++ b/amorphie.consent.core/DTO/ConsentDto.cs
@@ -19,6 +19,7 @@ public class ConsentDto : DtoBase
     public string State { get; set; }
     public DateTime StateModifiedAt { get; set; }
     public string? StateCancelDetailCode { get; set; }
+    public DateTime? LastValidAccessDate { get; set; }
     public string ConsentType { get; set; }
     public string AdditionalData { get; set; }
 }

--- a/amorphie.consent.core/DTO/OpenBanking/HHS/Consent/CancelConsentDto.cs
+++ b/amorphie.consent.core/DTO/OpenBanking/HHS/Consent/CancelConsentDto.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+using amorphie.core.Base;
+
+namespace amorphie.consent.core.DTO.OpenBanking.HHS;
+
+public class CancelConsentDto
+{
+    public Guid ConsentId { get; set; }
+    public string CancelDetailCode { get; set; }
+}

--- a/amorphie.consent.core/Enum/OpenBankingConstants.cs
+++ b/amorphie.consent.core/Enum/OpenBankingConstants.cs
@@ -278,7 +278,7 @@ public static class OpenBankingConstants
         public const string GKDIptali_OHKIstegiIleGKDdenVazgecildi = "13";
         public const string GKDIptali_FraudSuphesi = "14";
         public const string GKDIptali_Diger = "99";
-        public const string IBLogin_ContractIstegiIleIptal = "100";
+        public const string IBLogin_ServisIstegiIleIptal = "100";
     }
 
     public static class SrlmYon

--- a/amorphie.consent.core/Model/Consent.cs
+++ b/amorphie.consent.core/Model/Consent.cs
@@ -12,6 +12,7 @@ public class Consent : EntityBase
     public long? ScopeTCKN { get; set; }
     public string? Variant { get; set; }
     public string State { get; set; }
+    public DateTime? LastValidAccessDate { get; set; }
     public string? Description { get; set; }
     public string? XGroupId { get; set; }
     public string ConsentType { get; set; }

--- a/amorphie.consent.core/Model/OBAccountConsentDetail.cs
+++ b/amorphie.consent.core/Model/OBAccountConsentDetail.cs
@@ -21,7 +21,6 @@ public class OBAccountConsentDetail : EntityBase
     public string? DiscreteGKDDefinitionValue { get; set; }
     public DateTime? AuthCompletionTime { get; set; }
     public List<string> PermissionTypes { get; set; } = new();
-    public DateTime LastValidAccessDate { get; set; }
     public DateTime? TransactionInquiryStartTime { get; set; }
     public DateTime? TransactionInquiryEndTime { get; set; }
     public List<string>? AccountReferences { get; set; }

--- a/amorphie.consent.data/Migrations/20240515063458_ConsentLastValidDate.Designer.cs
+++ b/amorphie.consent.data/Migrations/20240515063458_ConsentLastValidDate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using amorphie.consent.data;
 namespace amorphie.consent.data.Migrations
 {
     [DbContext(typeof(ConsentDbContext))]
-    partial class ConsentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240515063458_ConsentLastValidDate")]
+    partial class ConsentLastValidDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/amorphie.consent.data/Migrations/20240515063458_ConsentLastValidDate.cs
+++ b/amorphie.consent.data/Migrations/20240515063458_ConsentLastValidDate.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace amorphie.consent.data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConsentLastValidDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                 name: "LastValidAccessDate",
+                 table: "OBAccountConsentDetails");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastValidAccessDate",
+                table: "Consents",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.InsertData(
+                  table: "OBErrorCodeDetails",
+                  columns: new[] { "Id", "BkmCode", "InternalCode", "Message", "MessageTr" },
+                  values: new object[,]
+                  {
+                            { new Guid("b6799e97-3a74-4e59-98e4-6c8230a0ec7e"), "TR.OHVPS.Business.InvalidContent", 203, "Invalid post message.", "İstek mesajı geçersiz." }
+                  });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastValidAccessDate",
+                table: "Consents");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastValidAccessDate",
+                table: "OBAccountConsentDetails",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+            migrationBuilder.DeleteData(
+                        table: "OBErrorCodeDetails",
+                        keyColumn: "Id",
+                        keyValue: new Guid("b6799e97-3a74-4e59-98e4-6c8230a0ec7e"));
+
+        }
+    }
+}
+
+
+
+

--- a/amorphie.consent/Helper/ConstantHelper.cs
+++ b/amorphie.consent/Helper/ConstantHelper.cs
@@ -8,18 +8,6 @@ public static class ConstantHelper
 {
 
     /// <summary>
-    /// Gets account consent status list that consent can be marked as deleted
-    /// </summary>
-    /// <returns>Deletable account consent status list</returns>
-    public static List<string> GetAccountConsentCanBeDeleteStatusList()
-    {
-        return new List<string>() { OpenBankingConstants.RizaDurumu.Yetkilendirildi,
-            OpenBankingConstants.RizaDurumu.YetkiBekleniyor,
-            OpenBankingConstants.RizaDurumu.YetkiKullanildi
-        };
-    }
-
-    /// <summary>
     /// Get account consent status list that can be marked as active statuses.
     /// In those statuses if new consent comes, it should be handled
     /// </summary>
@@ -262,6 +250,15 @@ public static class ConstantHelper
     public static List<int> GetVarYok()
     {
         return typeof(OpenBankingConstants.VarYok).GetAllPublicConstantValues<int>();
+    }
+    
+    /// <summary>
+    /// Get RizaIptalDetayKodu constants values list
+    /// </summary>
+    /// <returns>RizaIptalDetayKodu constants values list</returns>
+    public static List<string> GetRizaIptalDetayKoduList()
+    {
+        return typeof(OpenBankingConstants.RizaIptalDetayKodu).GetAllPublicConstantValues<string>();
     }
 
     /// <summary>

--- a/amorphie.consent/Helper/OBConsentValidationHelper.cs
+++ b/amorphie.consent/Helper/OBConsentValidationHelper.cs
@@ -1208,7 +1208,7 @@ public static class OBConsentValidationHelper
             result.Data = claims;
             return result; // Return the payload (claims)
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // Token validation failed
             result.Result = false;

--- a/amorphie.consent/Module/AuthorizationModule.cs
+++ b/amorphie.consent/Module/AuthorizationModule.cs
@@ -67,7 +67,7 @@ public class AuthorizationModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbCo
                     && c.UserTCKN == userTCKN
                     && ((c.ConsentType == ConsentConstants.ConsentType.OpenBankingAccount
                          && authAccountConsentStatusList.Contains(c.State)
-                         && c.OBAccountConsentDetails.Any(r => r.LastValidAccessDate > today))
+                         && c.LastValidAccessDate > today)
                         || (c.ConsentType == ConsentConstants.ConsentType.OpenBankingPayment
                             && authPaymentConsentStatusList.Contains(c.State))))
                 .ToListAsync();

--- a/amorphie.consent/Module/AuthorizationModule.cs
+++ b/amorphie.consent/Module/AuthorizationModule.cs
@@ -211,7 +211,7 @@ public class AuthorizationModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbCo
                                                        && c.LastValidAccessDate <= today
                                                        && c.State == OpenBankingConstants.RizaDurumu.YetkiKullanildi)
                 .ToList();
-            if (outDatedConsents?.Any() ?? false)
+            if (outDatedConsents.Any())
             {
                 //End consents
                 outDatedConsents = outDatedConsents.Select(c =>
@@ -225,8 +225,9 @@ public class AuthorizationModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbCo
 
             var toBeCancelledConsents =
                 consents.Where(c => c.State != OpenBankingConstants.RizaDurumu.YetkiSonlandirildi
-                && c.State != OpenBankingConstants.RizaDurumu.YetkiIptal).ToList();
-            if (toBeCancelledConsents?.Any() ?? false)
+                && c.State != OpenBankingConstants.RizaDurumu.YetkiIptal)
+                .ToList();
+            if (toBeCancelledConsents.Any())
             {
                 //End consents
                 toBeCancelledConsents = toBeCancelledConsents.Select(c =>

--- a/amorphie.consent/Module/ConsentModule.cs
+++ b/amorphie.consent/Module/ConsentModule.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Models;
 using amorphie.consent.data;
 using amorphie.consent.core.Model;
 using amorphie.consent.core.DTO;
+using amorphie.consent.core.DTO.Consent;
 using amorphie.consent.core.Enum;
 
 namespace amorphie.consent.Module;
@@ -29,6 +30,7 @@ public class ConsentModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbContext>
             "/GetUserConsents/clientCode={clientCode}&userTCKN={userTCKN}",
             GetUserConsents);
         routeGroupBuilder.MapDelete("/CancelLoginConsents", CancelLoginConsents);
+        routeGroupBuilder.MapDelete("/CancelLoginConsent", CancelLoginConsent);
     }
 
 
@@ -71,10 +73,6 @@ public class ConsentModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbContext>
     /// Cancels IBLogin types of yetkikullanildi state of consents.
     /// Consent state is turned to yetkiIptal state
     /// </summary>
-    /// <param name="context"></param>
-    /// <param name="mapper"></param>
-    /// <param name="configuration"></param>
-    /// <param name="httpContext"></param>
     /// <returns></returns>
     public async Task<IResult> CancelLoginConsents([FromServices] ConsentDbContext context,
         [FromServices] IMapper mapper,
@@ -85,7 +83,7 @@ public class ConsentModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbContext>
         {
             //Filter login consents
             var consents = await context.Consents.Where(c =>
-                    c.State == OpenBankingConstants.RizaDurumu.Yetkilendirildi
+                    c.State == OpenBankingConstants.RizaDurumu.YetkiKullanildi
                     && c.ConsentType == ConsentConstants.ConsentType.IBLogin)
                 .ToListAsync();
 
@@ -95,7 +93,54 @@ public class ConsentModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbContext>
                 c.ModifiedAt = DateTime.UtcNow;
                 c.State = OpenBankingConstants.RizaDurumu.YetkiIptal;
                 c.StateModifiedAt = DateTime.UtcNow;
-                c.StateCancelDetailCode = OpenBankingConstants.RizaIptalDetayKodu.IBLogin_ContractIstegiIleIptal;
+                c.StateCancelDetailCode = OpenBankingConstants.RizaIptalDetayKodu.IBLogin_ServisIstegiIleIptal;
+                return c;
+            }).ToList();
+
+            if (consents != null && consents.Any())
+            {
+                context.Consents.UpdateRange(consents);
+                await context.SaveChangesAsync();
+            }
+            return Results.Ok();
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem($"An error occurred: {ex.Message}");
+        }
+    }
+
+    
+    public async Task<IResult> CancelLoginConsent([FromBody] CancelLoginConsentDto cancelData,
+        [FromServices] ConsentDbContext context,
+        [FromServices] IMapper mapper,
+        [FromServices] IConfiguration configuration,
+        HttpContext httpContext)
+    {
+        try
+        {
+            //Check data validity
+            ApiResult isDataValidResult = IsDataValidToCancelLoginConsent(cancelData);
+            if (!isDataValidResult.Result) //Error in data validation
+            {
+                return Results.BadRequest(isDataValidResult.Message);
+            }
+            //Filter login consents
+            var consents = await context.Consents.Where(c =>
+                    c.State == OpenBankingConstants.RizaDurumu.YetkiKullanildi
+                    && c.ConsentType == ConsentConstants.ConsentType.IBLogin
+                    && c.ClientCode == cancelData.ClientCode
+                    && c.UserTCKN == cancelData.UserTCKN
+                    && c.ScopeTCKN == cancelData.ScopeTCKN)
+                .ToListAsync();
+
+            //Update consents
+            consents = consents?.Select(c =>
+            {
+                c.ModifiedAt = DateTime.UtcNow;
+                c.State = OpenBankingConstants.RizaDurumu.YetkiIptal;
+                c.StateModifiedAt = DateTime.UtcNow;
+                c.StateCancelDetailCode = OpenBankingConstants.RizaIptalDetayKodu.IBLogin_ServisIstegiIleIptal;
                 return c;
             }).ToList();
 
@@ -139,6 +184,34 @@ public class ConsentModule : BaseBBTRoute<ConsentDto, Consent, ConsentDbContext>
         return (resultList != null && resultList.Count > 0)
             ? Results.Ok(mapper.Map<IList<ConsentDto>>(resultList))
             : Results.NoContent();
+    }
+    
+   
+    /// <summary>
+    /// Checks cancelloginconsent data
+    /// </summary>
+    /// <param name="cancelData">To be checked data</param>
+    /// <returns>Data validation result</returns>
+    private ApiResult IsDataValidToCancelLoginConsent(CancelLoginConsentDto cancelData)
+    {
+        ApiResult result = new();
+
+        //check clientcode
+        if (string.IsNullOrEmpty(cancelData.ClientCode))
+        {
+            result.Result = false;
+            result.Message = "Client code parameter is required.";
+            return result;
+        }
+        //check tckn
+        if (cancelData.UserTCKN <= 0 || cancelData.ScopeTCKN <= 0)
+        {
+            result.Result = false;
+            result.Message = "usertckn, scope tckn not valid. Can not be zero or negative.";
+            return result;
+        }
+
+        return result;
     }
 
 

--- a/amorphie.consent/Module/OpenBankingHhsConsentModule.cs
+++ b/amorphie.consent/Module/OpenBankingHhsConsentModule.cs
@@ -1158,6 +1158,7 @@ public class OpenBankingHHSConsentModule : BaseBBTRoute<OpenBankingConsentDto, C
             consentEntity.ConsentType = ConsentConstants.ConsentType.OpenBankingAccount;
             consentEntity.Variant = hesapBilgisiRizasi.katilimciBlg.yosKod;
             consentEntity.ClientCode = string.Empty;
+            consentEntity.LastValidAccessDate = hesapBilgisiRizasi.hspBlg.iznBlg.erisimIzniSonTrh.ToUniversalTime();
             consentEntity.OBAccountConsentDetails = new List<OBAccountConsentDetail>
             {
                 GenerateAccountConsentDetailObject(hesapBilgisiRizasi, rizaIstegi, header)
@@ -3058,7 +3059,6 @@ public class OpenBankingHHSConsentModule : BaseBBTRoute<OpenBankingConsentDto, C
             DiscreteGKDDefinitionValue = hesapBilgisiRizasi.gkd.ayrikGkd?.ohkTanimDeger,
             AuthCompletionTime = hesapBilgisiRizasi.gkd.yetTmmZmn,
             PermissionTypes = hesapBilgisiRizasi.hspBlg.iznBlg.iznTur.ToList(),
-            LastValidAccessDate = hesapBilgisiRizasi.hspBlg.iznBlg.erisimIzniSonTrh.ToUniversalTime(),
             TransactionInquiryStartTime = hesapBilgisiRizasi.hspBlg.iznBlg.hesapIslemBslZmn?.ToUniversalTime(),
             TransactionInquiryEndTime = hesapBilgisiRizasi.hspBlg.iznBlg.hesapIslemBtsZmn?.ToUniversalTime(),
             OhkMessage = hesapBilgisiRizasi.hspBlg.ayrBlg?.ohkMsj,

--- a/amorphie.consent/Module/OpenBankingHhsConsentModule.cs
+++ b/amorphie.consent/Module/OpenBankingHhsConsentModule.cs
@@ -2610,7 +2610,7 @@ public class OpenBankingHHSConsentModule : BaseBBTRoute<OpenBankingConsentDto, C
     /// </summary>
     /// <param name="context"></param>
     /// <param name="activeAccountConsents">Consents to be checked</param>
-    private void CancelWaitingApproveConsents(ConsentDbContext context, List<Consent> activeAccountConsents)
+    private async Task  CancelWaitingApproveConsents(ConsentDbContext context, List<Consent> activeAccountConsents)
     {
         //Waiting approve state consents
         var waitingAporoves = activeAccountConsents
@@ -2635,6 +2635,7 @@ public class OpenBankingHHSConsentModule : BaseBBTRoute<OpenBankingConsentDto, C
             }
 
             context.Consents.UpdateRange(waitingAporoves);
+            await context.SaveChangesAsync();
         }
     }
 
@@ -2689,7 +2690,7 @@ public class OpenBankingHHSConsentModule : BaseBBTRoute<OpenBankingConsentDto, C
 
         await ProcessAccountConsentToCancelOrEnd(activeAccountConsents, context);
         //Cancel Yetki Bekleniyor state consents.
-        CancelWaitingApproveConsents(context, activeAccountConsents);
+        await CancelWaitingApproveConsents(context, activeAccountConsents);
         if (AnyAuthAndUsedConsents(activeAccountConsents)) //Checks any yetkilendirildi, yetki kullanıldı state consent
         {
             result.Result = false;

--- a/amorphie.consent/Service/AccountService.cs
+++ b/amorphie.consent/Service/AccountService.cs
@@ -635,7 +635,7 @@ public class AccountService : IAccountService
         }
             
         //Check consent status
-        if (consentDetail.LastValidAccessDate <  DateTime.UtcNow)
+        if (activeConsent.LastValidAccessDate <  DateTime.UtcNow)
         {
             //Consent revoked
             result.Result = false;

--- a/amorphie.consent/Service/OBAuthorizationService.cs
+++ b/amorphie.consent/Service/OBAuthorizationService.cs
@@ -40,10 +40,10 @@ public class OBAuthorizationService : IOBAuthorizationService
                 .AsNoTracking()
                 .Where(c =>
                     c.ConsentType == ConsentConstants.ConsentType.OpenBankingAccount
+                    && c.LastValidAccessDate > today
                     && c.State == consentState
                     && c.OBAccountConsentDetails.Any(i => i.IdentityData == userTCKN
                                                           && i.IdentityType == OpenBankingConstants.KimlikTur.TCKN
-                                                          && i.LastValidAccessDate > today
                                                           && i.UserType == OpenBankingConstants.OHKTur.Bireysel))
                 .ToListAsync();
             result.Data = activeAccountConsents;
@@ -69,11 +69,11 @@ public class OBAuthorizationService : IOBAuthorizationService
                     .Include(c => c.OBAccountConsentDetails)
                     .AsNoTracking()
                     .Where(c => c.Id.ToString() == consentId
+                                && c.LastValidAccessDate > today
                                 && c.ConsentType == ConsentConstants.ConsentType.OpenBankingAccount
                                 && c.State == consentState
                                 && c.OBAccountConsentDetails.Any(i =>
-                                    i.LastValidAccessDate > today
-                                    && i.UserType == OpenBankingConstants.OHKTur.Bireysel
+                                    i.UserType == OpenBankingConstants.OHKTur.Bireysel
                                     && i.AccountReferences != null
                                     && i.AccountReferences.Contains(accountRef)))
                     .ToListAsync())
@@ -192,10 +192,11 @@ public class OBAuthorizationService : IOBAuthorizationService
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.Id == id
                                           && consentTypes.Contains(c.ConsentType)
+                                          && (c.LastValidAccessDate == null
+                                              || (c.LastValidAccessDate != null && c.LastValidAccessDate > today))
                                           && (c.OBAccountConsentDetails.Any(i => i.IdentityData == userTCKN
                                                   && i.IdentityType ==
                                                   OpenBankingConstants.KimlikTur.TCKN
-                                                  && i.LastValidAccessDate > today
                                                   && i.UserType == OpenBankingConstants.OHKTur
                                                       .Bireysel
                                                   && i.Consent.ConsentType ==
@@ -231,9 +232,10 @@ public class OBAuthorizationService : IOBAuthorizationService
                 .Include(c => c.OBPaymentConsentDetails)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(c => c.ConsentType == consentType
+                                          && (c.LastValidAccessDate == null
+                                              || (c.LastValidAccessDate != null && c.LastValidAccessDate > today))
                                           && (c.OBAccountConsentDetails.Any(i =>
-                                                  i.LastValidAccessDate > today
-                                                  && i.YosCode == yosCode
+                                                  i.YosCode == yosCode
                                                   && i.CheckSumValue == checkSumValue
                                                   && i.CheckSumLastValiDateTime >= today
                                                   && i.Consent.ConsentType ==


### PR DESCRIPTION
#### Description

CancelLoginConsent method implemented to cancel iblogin type consent.
CancelConsent method implemented  to cancel account-payment open banking not finilized consent.
Consent entity LastValidAccessDate clm added. This change reflected to ConsentModule get post methods, authorizationmodule methods.
LastValidAccessDate clm removed from OBAccountConsentDetail table. OpenBanking codes updated to use consent LastValidAccessDate clm. Migration added

Fixes # (issue)

#### Type of change

- [X] New feature (non-breaking change which adds functionality)

#### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

#### Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
